### PR TITLE
js: fix accessor color

### DIFF
--- a/src/token-colors/javascript.js
+++ b/src/token-colors/javascript.js
@@ -13,6 +13,13 @@ const javascript = (palette /*: Palette */) => [
     }
   },
   {
+    name: `JS - Accessor`,
+    scope: `source.js keyword.operator.accessor`,
+    settings: {
+      foreground: palette.magenta
+    }
+  },
+  {
     name: `JS - Object Property Keys`,
     scope: `source.js string.unquoted`,
     settings: {


### PR DESCRIPTION
Before:
<img width="302" alt="Screen Shot 2019-05-18 at 2 26 49 PM" src="https://user-images.githubusercontent.com/1024544/57975164-039aef80-7979-11e9-8dfd-6267573760d6.png">

After:
<img width="325" alt="Screen Shot 2019-05-18 at 2 26 26 PM" src="https://user-images.githubusercontent.com/1024544/57975166-04cc1c80-7979-11e9-9725-b4c64bd2c678.png">
