### PR TITLE
README: add color pallete

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > A dark theme for VS Code
 
-
 ![Full Preview](static/preview/full-preview.png)
 
 | JavaScript | React | Vue |
@@ -30,6 +29,24 @@ You can find the Neon Night theme in the [Visual Studio Code Marketplace](https:
 4. Click **Reload** to reload VS Code
 5. From the menu bar click: Code > Preferences > Color Theme > **Neon Night** (or any of the variants listed)
 6. 🎉🎉 Enjoy!
+
+## Syntax Colors
+
+|      USAGE       |                                HEX CODES                                 |
+| ---------------- | ------------------------------------------------------------------------ |
+| Background       | ![#20242d](https://placehold.it/15/20242d/000000?text=+) `#20242d`       |
+| Background Dark  | ![#1B1E26](https://placehold.it/15/1B1E26/000000?text=+) `#1B1E26`       |
+| Foreground       | ![#C7C8FF](https://placehold.it/15/C7C8FF/000000?text=+) `#C7C8FF`       |
+| Black       | ![#20242d](https://placehold.it/15/20242d/000000?text=+) `#20242d`       |
+| White       | ![#C7C8FF](https://placehold.it/15/C7C8FF/000000?text=+) `#C7C8FF`       |
+| Magenta         | ![#DD92F6](https://placehold.it/15/DD92F6/000000?text=+) `#DD92F6`       |
+| Blue         | ![#69B4F9](https://placehold.it/15/69B4F9/000000?text=+) `#69B4F9`       |
+| Cyan        | ![#8CE8ff](https://placehold.it/15/8CE8ff/000000?text=+) `#8CE8ff`       |
+| Green        | ![#7EFDD0](https://placehold.it/15/7EFDD0/000000?text=+) `#7EFDD0`       |
+| Red        | ![#FF8E8E](https://placehold.it/15/FF8E8E/000000?text=+) `#FF8E8E`       |
+| Yellow        | ![#FCAD3F](https://placehold.it/15/FCAD3F/000000?text=+) `#FCAD3F`       |
+| Diff Added       | ![#7EFDD011](https://placehold.it/15/7EFDD011/000000?text=+) `#7EFDD011` |
+| Diff Removed     | ![#FF8E8E11](https://placehold.it/15/FF8E8E11/000000?text=+) `#FF8E8E11` |
 
 ## Development
 

--- a/src/theme-color-properties/sidebar.js
+++ b/src/theme-color-properties/sidebar.js
@@ -1,0 +1,11 @@
+const SIDEBAR = {
+  SIDEBARTITLE_FOREGROUND: `sideBarTitle.foreground`,
+  SIDEBARSECTIONHEADER_BORDER: `sideBarSectionHeader.border`,
+  SIDEBARSECTIONHEADER_BACKGROUND: `sideBarSectionHeader.background`,
+  SIDEBARSECTIONHEADER_FOREGROUND: `sideBarSectionHeader.foreground`,
+  SIDEBAR_BORDER: `sideBar.border`,
+  SIDEBAR_BACKGROUND: `sideBar.background`,
+  SIDEBARTITLE_FOREGROUND: `sideBarTitle.foreground`
+};
+
+module.exports = SIDEBAR;


### PR DESCRIPTION
Add Syntax colors so that it's easy for folks to override with the same palette: 

![image](https://user-images.githubusercontent.com/1024544/57975263-68a31500-797a-11e9-9b1a-6de668e119d5.png)
