### PR TITLE
quickOpen: add colors for quick open

### DIFF
--- a/src/colors/quick-input.js
+++ b/src/colors/quick-input.js
@@ -4,13 +4,10 @@
 import type {Palette} from '../types'
 */
 
-
 // https://code.visualstudio.com/api/references/theme-color#quick-picker
 const quickInput = (palette /*: Palette */) => ({
-    "quickInput.background": palette.blackest,
-    "quickInput.foreground": palette.white
+  "quickInput.background": palette.blackest,
+  "quickInput.foreground": palette.white
 });
 
 module.exports = quickInput;
-
-

--- a/src/colors/quick-input.js
+++ b/src/colors/quick-input.js
@@ -1,0 +1,16 @@
+// @flow
+
+/* ::
+import type {Palette} from '../types'
+*/
+
+
+// https://code.visualstudio.com/api/references/theme-color#quick-picker
+const quickInput = (palette /*: Palette */) => ({
+    "quickInput.background": palette.blackest,
+    "quickInput.foreground": palette.white
+});
+
+module.exports = quickInput;
+
+

--- a/src/generate-theme.js
+++ b/src/generate-theme.js
@@ -32,6 +32,7 @@ const generateTheme = (
     ...require(`./colors/menu-bar`)(palette),
     ...require(`./colors/notification`)(palette),
     ...require(`./colors/quick-picker`)(palette),
+    ...require(`./colors/quick-input`)(palette),
     ...require(`./colors/integrated-terminal`)(palette),
     ...require(`./colors/debug`)(palette),
     ...require(`./colors/git`)(palette),


### PR DESCRIPTION
use the new `quickOpen` feature in VS Code.

<img width="1180" alt="Screen Shot 2019-07-22 at 9 28 05 PM" src="https://user-images.githubusercontent.com/1024544/61682808-f5928380-acc7-11e9-8d19-6dcd3a8554eb.png">
