### PR TITLE
fix list highlighting

### DIFF
--- a/src/colors/base.js
+++ b/src/colors/base.js
@@ -8,6 +8,7 @@ import type {Palette} from '../types'
 const baseColors = (palette /*: Palette */) => ({
   foreground: palette.white,
   focusBorder: palette.magenta77,
+  contrastBorder: palette.magenta77,
   "widget.shadow": palette.black,
   "selection.background": palette.magenta33,
   descriptionForeground: palette.white,

--- a/src/colors/editor-widget.js
+++ b/src/colors/editor-widget.js
@@ -11,7 +11,8 @@ const editorWidget = (palette /*: Palette */) => ({
   "editorSuggestWidget.background": palette.black,
   "editorSuggestWidget.foreground": palette.white,
   "editorSuggestWidget.highlightForeground": palette.magenta,
-  "editorSuggestWidget.selectedBackground": palette.black,
+  "editorSuggestWidget.selectedBackground": palette.blackout,
+  "editorHoverWidget.background": palette.blackest,
   // editor marker navigation
   "editorMarkerNavigation.background": palette.black,
   "editorMarkerNavigationError.background": palette.red,

--- a/src/colors/editor-widget.js
+++ b/src/colors/editor-widget.js
@@ -11,7 +11,7 @@ const editorWidget = (palette /*: Palette */) => ({
   "editorSuggestWidget.background": palette.black,
   "editorSuggestWidget.foreground": palette.white,
   "editorSuggestWidget.highlightForeground": palette.magenta,
-  "editorSuggestWidget.selectedBackground": palette.blackout,
+  "editorSuggestWidget.selectedBackground": palette.blackest,
   "editorHoverWidget.background": palette.blackest,
   // editor marker navigation
   "editorMarkerNavigation.background": palette.black,

--- a/src/colors/quick-input.js
+++ b/src/colors/quick-input.js
@@ -6,7 +6,7 @@ import type {Palette} from '../types'
 
 // https://code.visualstudio.com/api/references/theme-color#quick-picker
 const quickInput = (palette /*: Palette */) => ({
-  "quickInput.background": palette.blackest,
+  "quickInput.background": palette.black,
   "quickInput.foreground": palette.white
 });
 


### PR DESCRIPTION


An attempt to fix #23 and #24 the way that works best for me (feel free to weigh in if you think this is too heavy handed).

## command palette

- adds border for command palette
- adds better active selection color for item in command palette

Before: 
![Kapture 2019-12-01 at 5 55 47](https://user-images.githubusercontent.com/1024544/69915023-501eb780-13ff-11ea-9a3d-4df22a74fafa.gif)

After: 
![Kapture 2019-12-01 at 5 50 39](https://user-images.githubusercontent.com/1024544/69915030-6298f100-13ff-11ea-8c46-5df24ddd2e7c.gif)

## suggestion widget

- adds better active selection colors for item in command palette

Before:
![Kapture 2019-12-01 at 5 52 44](https://user-images.githubusercontent.com/1024544/69915039-7b090b80-13ff-11ea-9856-9de182473c49.gif)

After:
![Kapture 2019-12-01 at 6 05 26](https://user-images.githubusercontent.com/1024544/69915136-9c1e2c00-1400-11ea-9ae6-d48328777cc4.gif)



